### PR TITLE
Relax the cross validation for the 'rémunérations' indicateur

### DIFF
--- a/egapro/schema/__init__.py
+++ b/egapro/schema/__init__.py
@@ -93,7 +93,13 @@ def _cross_validate(data):
         elif data.path(path) is not None:
             resultat = data.path(f"{path}.résultat")
             msg = f"{path}.résultat must be set when indicateur is calculable"
-            assert resultat is not None, msg
+            if key != "rémunérations" or data.path(f"{path}.population_favorable"):
+                # The "rémunérations" indicator is sent through several steps
+                # on the "formulaire" frontend. The only way the "formulaire"
+                # sent all its data is if there's a `population_favorable`
+                # field. However, this latter field is only provided if the
+                # `résultat` is not `0`.
+                assert resultat is not None, msg
     keys = ["rémunérations", "augmentations", "promotions"]
     for key in keys:
         path = f"indicateurs.{key}"

--- a/test/api/test_declaration.py
+++ b/test/api/test_declaration.py
@@ -597,7 +597,16 @@ async def test_basic_declaration_with_niveau_branche_without_cse(client, body):
 
 
 async def test_basic_declaration_without_resultat(client, body):
-    body["indicateurs"] = {"rémunérations": {"mode": "csp"}}
+    body["indicateurs"] = {"augmentations": {"catégories": [1, 2, 3, 4]}}
+    resp = await client.put("/declaration/514027945/2019", body=body)
+    assert resp.status == 422
+    assert json.loads(resp.body) == {
+        "error": "indicateurs.augmentations.résultat must be set when indicateur is calculable"
+    }
+
+
+async def test_remunerations_declaration_without_resultat(client, body):
+    body["indicateurs"] = {"rémunérations": {"mode": "csp", "population_favorable": "femmes"}}
     resp = await client.put("/declaration/514027945/2019", body=body)
     assert resp.status == 422
     assert json.loads(resp.body) == {


### PR DESCRIPTION
Attempt at a more relaxed (but not totally absent)  cross-validation on `indicateurs.rémunérations.résultat`.

The current cross-validation would break the frontend (formulaire) since https://github.com/SocialGouv/egapro-api/commit/8058025ed15ea60ad31b2a3f3d31ae8965abb6f1#diff-957f484be13f6fd04b941bab1d5852fd817d1f729d1e8f6b442e2313a77da86eR85-R88 because the `indicateurs.rémunérations` data is sent in several steps
- remuneration.html : choose the mode (or non-calculable)
- remuneration-(csp|coef).html : enter the various data for `catégories`
- remuneration-final.htm : enter the final `résultat` and the `population_favorable`