### PR TITLE
chore: POC of non duplicating public data in search table

### DIFF
--- a/egapro/db.py
+++ b/egapro/db.py
@@ -217,7 +217,6 @@ class search(table):
                 siren,
                 year,
                 declared_at,
-                declaration.public_data(data),
                 ft,
                 region,
                 departement,
@@ -239,9 +238,10 @@ class search(table):
                 where.append(f"{name}=${len(args)}")
         if where:
             where = "WHERE " + " AND ".join(where)
-        return await cls.fetch(
+        rows = await cls.fetch(
             sql.search.format(where=where or ""), *args
         )
+        return [declaration.public_data(row["data"]) for row in rows]
 
     @classmethod
     async def truncate(cls):

--- a/egapro/sql/create_search_table.sql
+++ b/egapro/sql/create_search_table.sql
@@ -1,3 +1,3 @@
 CREATE TABLE IF NOT EXISTS search
-(siren TEXT, year INT, declared_at TIMESTAMP WITH TIME ZONE, data JSONB, ft TSVECTOR, region VARCHAR(2), departement VARCHAR(3), code_naf VARCHAR(6), note INT,
+(siren TEXT, year INT, declared_at TIMESTAMP WITH TIME ZONE, ft TSVECTOR, region VARCHAR(2), departement VARCHAR(3), code_naf VARCHAR(6), note INT,
 PRIMARY KEY (siren, year));

--- a/egapro/sql/index_declaration.sql
+++ b/egapro/sql/index_declaration.sql
@@ -1,4 +1,4 @@
-INSERT INTO search (siren, year, declared_at, data, ft, region, departement, code_naf, note)
-VALUES ($1, $2, $3, $4, to_tsvector('ftdict', $5), $6, $7, $8, $9)
+INSERT INTO search (siren, year, declared_at, ft, region, departement, code_naf, note)
+VALUES ($1, $2, $3, to_tsvector('ftdict', $4), $5, $6, $7, $8)
 ON CONFLICT (siren, year) DO UPDATE
-SET declared_at=$3, data=$4, ft=to_tsvector('ftdict', $5), region=$6, departement=$7, code_naf=$8, note=$9
+SET declared_at=$3, ft=to_tsvector('ftdict', $4), region=$5, departement=$6, code_naf=$7, note=$8

--- a/egapro/sql/search.sql
+++ b/egapro/sql/search.sql
@@ -1,5 +1,7 @@
-SELECT data FROM search
-{where}
-ORDER BY declared_at DESC
-LIMIT $1
-OFFSET $2
+SELECT data FROM declaration WHERE (siren, year) in (
+    SELECT siren, year FROM search
+    {where}
+    ORDER BY declared_at DESC
+    LIMIT $1
+    OFFSET $2
+)

--- a/egapro/views.py
+++ b/egapro/views.py
@@ -255,7 +255,7 @@ async def search(request, response):
         departement=departement,
         region=region,
     )
-    response.json = {"data": [r.data for r in results], "total": len(results)}
+    response.json = {"data": results, "total": len(results)}
 
 
 @app.route("/config")

--- a/test/test_ft.py
+++ b/test/test_ft.py
@@ -47,7 +47,7 @@ async def test_search(client):
         )
     results = await db.search.run("total")
     assert len(results) == 1
-    assert results[0].data == {
+    assert results[0] == {
         "declaration": {"noteIndex": None},
         "id": None,
         "informationsEntreprise": {
@@ -93,7 +93,7 @@ async def test_small_companies_are_not_searchable(declaration):
     )
     results = await db.search.run("bar")
     assert len(results) == 2
-    names = {r.data["informationsEntreprise"]["nomEntreprise"] for r in results}
+    names = {r["informationsEntreprise"]["nomEntreprise"] for r in results}
     assert names == {"Mala Bar", "Karam Bar"}
 
 
@@ -120,7 +120,7 @@ async def test_search_from_ues_name(client):
     )
     results = await db.search.run("ues")
     assert len(results) == 1
-    assert results[0].data == {
+    assert results[0] == {
         "declaration": {"noteIndex": None},
         "id": None,
         "informationsEntreprise": {
@@ -159,7 +159,7 @@ async def test_search_from_ues_member_name(client):
     )
     results = await db.search.run("foo")
     assert len(results) == 1
-    assert results[0].data == {
+    assert results[0] == {
         "declaration": {"noteIndex": None},
         "id": None,
         "informationsEntreprise": {
@@ -206,7 +206,7 @@ async def test_search_with_filters(client):
     )
     results = await db.search.run("bar", departement="78", region="11")
     assert len(results) == 1
-    assert results[0].data == {
+    assert results[0] == {
         "declaration": {"noteIndex": None},
         "id": None,
         "informations": {"anneeDeclaration": 2020},
@@ -253,7 +253,7 @@ async def test_filters_without_query(client):
     )
     results = await db.search.run(departement="78", region="11")
     assert len(results) == 1
-    assert results[0].data == {
+    assert results[0] == {
         "declaration": {"noteIndex": None},
         "id": None,
         "informations": {"anneeDeclaration": 2020},
@@ -302,7 +302,7 @@ async def test_search_with_offset(client):
     assert len(results) == 2
     results = await db.search.run(region="11", limit=1)
     assert len(results) == 1
-    assert results[0].data == {
+    assert results[0] == {
         "declaration": {"noteIndex": None},
         "id": None,
         "informations": {"anneeDeclaration": 2020},
@@ -318,7 +318,7 @@ async def test_search_with_offset(client):
     }
     results = await db.search.run(region="11", limit=1, offset=1)
     assert len(results) == 1
-    assert results[0].data == {
+    assert results[0] == {
         "declaration": {"noteIndex": None},
         "id": None,
         "informations": {"anneeDeclaration": 2020},


### PR DESCRIPTION
Just to decide if we prefer to duplicate public data in the search table or not.

With:
```
egapro=# EXPLAIN ANALYSE SELECT data FROM search WHERE departement='56' AND region='53' ORDER BY declared_at DESC LIMIT 10 OFFSET 0;
                                                               QUERY PLAN                                                               
----------------------------------------------------------------------------------------------------------------------------------------
 Limit  (cost=304.07..304.08 rows=5 width=397) (actual time=0.476..0.482 rows=10 loops=1)
   ->  Sort  (cost=304.07..304.08 rows=5 width=397) (actual time=0.473..0.476 rows=10 loops=1)
         Sort Key: declared_at DESC
         Sort Method: top-N heapsort  Memory: 30kB
         ->  Bitmap Heap Scan on search  (cost=5.08..304.01 rows=5 width=397) (actual time=0.097..0.395 rows=106 loops=1)
               Recheck Cond: ((departement)::text = '56'::text)
               Filter: ((region)::text = '53'::text)
               Heap Blocks: exact=96
               ->  Bitmap Index Scan on idx_departement  (cost=0.00..5.08 rows=106 width=0) (actual time=0.046..0.047 rows=120 loops=1)
                     Index Cond: ((departement)::text = '56'::text)
 Planning Time: 0.219 ms
 Execution Time: 0.540 ms

```

Without:

```
egapro=# EXPLAIN ANALYSE SELECT data FROM declaration WHERE (siren, year) IN (SELECT siren, year FROM search WHERE departement='56' AND region='53' ORDER BY declared_at DESC LIMIT 10 OFFSET 0);
                                                                     QUERY PLAN                                                                     
----------------------------------------------------------------------------------------------------------------------------------------------------
 Nested Loop  (cost=304.45..329.12 rows=1 width=1113) (actual time=0.504..0.638 rows=10 loops=1)
   ->  HashAggregate  (cost=304.16..304.19 rows=3 width=14) (actual time=0.477..0.486 rows=10 loops=1)
         Group Key: search.siren, search.year
         Batches: 1  Memory Usage: 24kB
         ->  Limit  (cost=304.07..304.08 rows=5 width=22) (actual time=0.453..0.458 rows=10 loops=1)
               ->  Sort  (cost=304.07..304.08 rows=5 width=22) (actual time=0.451..0.454 rows=10 loops=1)
                     Sort Key: search.declared_at DESC
                     Sort Method: top-N heapsort  Memory: 25kB
                     ->  Bitmap Heap Scan on search  (cost=5.08..304.01 rows=5 width=22) (actual time=0.089..0.376 rows=106 loops=1)
                           Recheck Cond: ((departement)::text = '56'::text)
                           Filter: ((region)::text = '53'::text)
                           Heap Blocks: exact=96
                           ->  Bitmap Index Scan on idx_departement  (cost=0.00..5.08 rows=106 width=0) (actual time=0.039..0.040 rows=120 loops=1)
                                 Index Cond: ((departement)::text = '56'::text)
   ->  Index Scan using declaration_pkey on declaration  (cost=0.29..8.31 rows=1 width=1127) (actual time=0.013..0.013 rows=1 loops=10)
         Index Cond: ((siren = search.siren) AND (year = search.year))
 Planning Time: 1.361 ms
 Execution Time: 0.745 ms

```